### PR TITLE
:arrow_up: Add `scikit-learn` as dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ numpy>=1.19.2
 matplotlib>=3.3.2
 scipy>=1.5.2
 emcee>=3.0.2
-sklearn
+scikit-learn
 astropy>=4.2


### PR DESCRIPTION
Replacing `sklearn` with `sckit-learn` in `requirements.txt` fixes issue #4 